### PR TITLE
Fix wrong closing parens.

### DIFF
--- a/turnstyle.js
+++ b/turnstyle.js
@@ -388,7 +388,7 @@ class Parser {
                 const right = this._area(this._pixelR());
                 if (left === 1) {
                     const n = BigInt(front) ** BigInt(right);
-                    return new LitExpr(new Num(new Rational(n), this._loc()));
+                    return new LitExpr(new Num(new Rational(n)), this._loc());
                 } else if (left === 2) {
                     if (Primitives[front] && Primitives[front][right]) {
                         const primitive = Primitives[front][right];


### PR DESCRIPTION
I was wondering why it wasnt showing the location of the Literal Expressions in the playground. Seems to be a wrong closing paren that went unnoticed.